### PR TITLE
abort method calls abort method (infinite loop)

### DIFF
--- a/BinaryTransport/jquery.binarytransport.js
+++ b/BinaryTransport/jquery.binarytransport.js
@@ -44,9 +44,7 @@ $.ajaxTransport("+binary", function(options, originalOptions, jqXHR){
                 xhr.responseType = dataType;
                 xhr.send(data);
             },
-            abort: function(){
-                jqXHR.abort();
-            }
+            abort: function(){}
         };
     }
 });


### PR DESCRIPTION
See abort function on @jquery:
https://github.com/jquery/jquery/blob/master/src/ajax.js#L482

When `jqXHR.abort` gets called it checks for and calls the transport's `abort` function.