### PR TITLE
A fix for #7: No error on network fail

### DIFF
--- a/BinaryTransport/jquery.binarytransport.js
+++ b/BinaryTransport/jquery.binarytransport.js
@@ -35,6 +35,12 @@
                         // make callback and send data
                         callback(xhr.status, xhr.statusText, data, xhr.getAllResponseHeaders());
                     });
+                    xhr.addEventListener('error', function() {
+                        var data = {};
+                        data[options.dataType] = xhr.response;
+                        // make callback and send data
+                        callback(xhr.status, xhr.statusText, data, xhr.getAllResponseHeaders());
+                    });
 
                     xhr.open(type, url, async, username, password);
 


### PR DESCRIPTION
This will make sure that both .fail() and .always() are called if a network-error occurs when doing the request.

Not sure this is the correct approach, but for my use case it works.
