### PR TITLE
Synchronous call cannot be made

### DIFF
--- a/BinaryTransport/jquery.binarytransport.js
+++ b/BinaryTransport/jquery.binarytransport.js
@@ -22,7 +22,7 @@
                     var xhr = new XMLHttpRequest(),
                         url = options.url,
                         type = options.type,
-                        async = options.async || true,
+                        async = options.async !== false,
                         // blob or arraybuffer. Default is blob
                         dataType = options.responseType || "blob",
                         data = options.data || null,


### PR DESCRIPTION
The following code would be treated as true regardless of the value of options.async.
```
async = options.async || true,
```
The following modifications were made to the intended process.
```
async = options.async !== false,
```